### PR TITLE
Add detailed error message for unregistered event type

### DIFF
--- a/lib/rising_dragon/sqs/emitter.rb
+++ b/lib/rising_dragon/sqs/emitter.rb
@@ -37,7 +37,7 @@ module RisingDragon
 
       def emit_event(event)
         handler = @handlers[event.type]
-        raise ::RisingDragon::UnRegisterEvent unless handler
+        raise ::RisingDragon::UnRegisterEvent, "event_type: `#{event.type}` is unregistered" unless handler
 
         handler.new.handle(event)
 


### PR DESCRIPTION
I've added detailed error message for unregistered event type
because now we can only know when there are are UnRegisteredEvent and can't know which event_type is not registered.