### PR TITLE
Remove Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/ota42y/rising_dragon.svg?branch=master)](https://travis-ci.org/ota42y/rising_dragon)
-[![Dependency Status](https://gemnasium.com/badges/github.com/ota42y/rising_dragon.svg)](https://gemnasium.com/github.com/ota42y/rising_dragon)
 [![Code Climate](https://codeclimate.com/github/ota42y/rising_dragon/badges/gpa.svg)](https://codeclimate.com/github/ota42y/rising_dragon)
 
 # RisingDragon


### PR DESCRIPTION
[Gemnasium](https://gemnasium.com/) is already closed...

https://docs.gitlab.com/ee/user/project/import/gemnasium.html